### PR TITLE
resolveHandleエンドポイントにDIDのバリデーションを追加

### DIFF
--- a/backend/src/api/resolveHandle.ts
+++ b/backend/src/api/resolveHandle.ts
@@ -19,6 +19,11 @@ export const handle = async (c: Context) => {
     const text = await response.text();
     const did = text.split("\n")[0]!.trim();
 
+	// validate did
+    if (!did.startsWith("did:plc:") && !did.startsWith("did:web:")) {
+        return c.json({ error: "Invalid DID" }, 400);
+    }
+
     return c.json({ did });
   } catch (err: unknown) {
     if (err instanceof Error) {


### PR DESCRIPTION
## 概要
DNSベースのハンドル解決を使用しているかつそのドメインでSPAをホスティングしている場合にログインできない問題を修正
## 問題
1. `resolveHandleViaHttp`内で`/xrpc/uk.skyblur.admin.resolveHandle`にリクエストを飛ばす
2. サーバー側で、ハンドルを解決するために`https://handle.example/.well-known/atproto-did`にアクセス
3. ページがないため、SPAの場合はindex.htmlが200で返される
4. HTMLの一行目をDIDと誤認して200でレスポンスを返してしまう
  レスポンス例
```JSON
{ "did": "<!doctype html>" }
```
5. ステータスコードが200のため、`resolveHandleViaHttp`でエラーを投げてDoHにフォールバックすべきところを正常に通してしまう
6. DIDが異常なままその先へ進んでしまい、エラーになってログインできない  
## 解決策
`resolveHandle`で正しいDIDであることを確認し不正なDIDの場合は400を返すことで、DoHへのフォールバックが正しく動作するようになります。