### PR TITLE
Fix oauth_did cookie DID parsing for did:web values

### DIFF
--- a/backend/src/logic/AuthUtils.ts
+++ b/backend/src/logic/AuthUtils.ts
@@ -53,9 +53,9 @@ export const getAuthenticatedDid = async (c: Context): Promise<string | null> =>
     }
 
     if (rawDid) {
-        const parts = rawDid.split('.');
-        if (parts.length === 2) {
-            const [did] = parts;
+        const lastDotIndex = rawDid.lastIndexOf('.');
+        if (lastDotIndex !== -1) {
+            const did = rawDid.substring(0, lastDotIndex);
             const expectedSigned = await signDid(did, secret);
             if (rawDid === expectedSigned) {
                 return did;

--- a/backend/src/logic/__tests__/AuthUtils.test.ts
+++ b/backend/src/logic/__tests__/AuthUtils.test.ts
@@ -100,6 +100,30 @@ describe('AuthUtils', () => {
             expect(did).toBe(storedDid);
         });
 
+        it('should return DID from cookie for did:web identifiers that include dots', async () => {
+            const secret = 'secret-key';
+            const storedDid = 'did:web:app.example.com';
+            const signedDid = await signDid(storedDid, secret);
+
+            const c: any = {
+                req: {
+                    header: vi.fn(),
+                    raw: {
+                        headers: new Headers({
+                            'Cookie': `oauth_did=${signedDid}`
+                        })
+                    }
+                },
+                env: {
+                    OAUTH_PRIVATE_KEY_JWK: secret,
+                    APPVIEW_HOST: 'app.example.com'
+                }
+            };
+
+            const did = await getAuthenticatedDid(c);
+            expect(did).toBe(storedDid);
+        });
+
         it('should return null if cookie has invalid format', async () => {
             const c: any = {
                 req: {


### PR DESCRIPTION
### Motivation
- Cookie-based auth stored `oauth_did` as `{did}.{signature}`, but the previous parsing used `split('.')` which breaks when the DID itself contains dots (e.g., `did:web:app.example.com`).
- This caused valid `did:web` identifiers to be rejected during cookie-based authentication and needed a robust parsing fix.

### Description
- Change cookie parsing in `getAuthenticatedDid` to split on the last dot using `lastIndexOf('.')` and `substring` so the DID portion can contain dots (file: `backend/src/logic/AuthUtils.ts`).
- Add a regression test asserting a signed `did:web:app.example.com` cookie is accepted (file: `backend/src/logic/__tests__/AuthUtils.test.ts`).

### Testing
- Ran the new test file with `cd backend && pnpm vitest run src/logic/__tests__/AuthUtils.test.ts` and it passed (`1 passed, 8 tests`).
- Ran the full test suite with `cd backend && pnpm test` and all tests passed (`14 files, 110 tests passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecc4ab8d7c8327b9e27aff529952ad)